### PR TITLE
[escape-character] アポストロフィの置換処理を追加

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -381,6 +381,7 @@ const convertHeader = (_rootObj) => {
             g_rawData += `|`;
         }
     }
+    g_rawData = g_rawData.replace(/'/g, `&#39;`);
 }
 
 // ファイルごとの変換処理


### PR DESCRIPTION
## 変更内容
- アポストロフィの置換処理を追加

## 変更理由
- 埋め込みdosとして利用する場合、アポストロフィのエスケープ処理が必要なため。