### PR TITLE
[0004-old-colormode] 古い色変化仕様に対応、difDataが表示されない問題を修正

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -22,7 +22,7 @@ body {
 
 .droparea {
   width: 100%;
-  height: 100%;
+  height: 90%;
   border: 32px solid var(--color1);
   font-size: 5vw;
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <link rel="stylesheet" type="text/css" href="css/main.css">
   </head>
   <body>
+    <form name="options">
+      変換元の色変化仕様：
+      <input type="radio" name="colorFlg" value="current" checked="checked"> ParaFla (現行)　
+      <input type="radio" name="colorFlg" value="old"> ParaFla (MFV2さんソースv4以前)
+    </form>
     <div id="droparea" class="droparea">
       JavaScriptが無効か、非対応のブラウザです
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,9 @@ const g_keyObj = {
     }
 };
 
+g_colorFlg = `current`;
 g_keyObj.cCom = [];
+g_keyObj.cComOld = [];
 g_keyObj.c5 = [];
 g_keyObj.c7 = [];
 g_keyObj.c7i = [];
@@ -62,6 +64,7 @@ for (let j = 0; j < 62; j++) {
     g_keyObj.c16i[j] = j;
     g_keyObj.c17[j] = j;
     g_keyObj.cCom[j] = j;
+    g_keyObj.cComOld[j] = j;
 }
 
 g_keyObj.cCom[21] = 22;
@@ -79,6 +82,12 @@ g_keyObj.cCom[52] = 53;
 g_keyObj.cCom[53] = 52;
 g_keyObj.cCom[57] = 58;
 g_keyObj.cCom[58] = 57;
+
+g_keyObj.cComOld[11] = 60;
+g_keyObj.cComOld[12] = 61;
+g_keyObj.cComOld[13] = 20;
+g_keyObj.cComOld[14] = 21;
+g_keyObj.cComOld[15] = 23;
 
 // [0, 2, 4, 6, 3] => [0, 1, 2, 3, 4]
 g_keyObj.c5[0] = 0;
@@ -281,10 +290,13 @@ const dosConvert = (_dos) => {
         if (pos > 0) {
             const pKey = params[j].substring(0, pos);
             const pValue = params[j].substring(pos + 1);
-            if (pKey === `difStep` || pKey === `difName` || pKey === `speedlock` || pKey === `difData` ||
+            if (pKey === `difStep` || pKey === `difName` || pKey === `speedlock` ||
                 (pKey.substring(0, 5) === `color` && pKey.endsWith(`_data`)) ||
                 (pKey.substring(0, 6) === `acolor` && pKey.endsWith(`_data`))) {
                 obj[pKey] = pValue;
+            } else if (pKey === `difData`) {
+                obj[pKey] = pValue;
+                g_rawData += `|${params[j]}|\r\n`;
             } else {
                 g_rawData += `|${params[j]}|\r\n`;
             }
@@ -295,7 +307,11 @@ const dosConvert = (_dos) => {
 
 // カラーNoの変換
 const convertColorNo = (_key, _no) => {
-    return (_no < 20 ? g_keyObj[`c${_key}`][_no] : g_keyObj.cCom[_no]);
+    if (g_colorFlg === `current`) {
+        return (_no < 20 ? g_keyObj[`c${_key}`][_no] : g_keyObj.cCom[_no]);
+    } else {
+        return (_no < 11 ? g_keyObj[`c${_key}`][_no] : g_keyObj.cComOld[_no]);
+    }
 }
 
 // 抽出したデータのみ変換処理を掛ける
@@ -386,6 +402,13 @@ const convertHeader = (_rootObj) => {
 
 // ファイルごとの変換処理
 const convert = file => {
+    const colorFlg = document.options.colorFlg;
+    if (colorFlg[0].checked) {
+        g_colorFlg = `current`;
+    } else if (colorFlg[1].checked) {
+        g_colorFlg = `old`;
+    }
+
     const reader = new FileReader();
 
     reader.onload = () => {


### PR DESCRIPTION
## 変更内容
1. 古い色変化仕様に対応
1. difDataが出力されない問題を修正

## 変更理由
1. ParaFlaソース(MFV2さんソース Ver4以前)では、色変化仕様が異なるため。
1. キー数取得のためにdifDataを別取りしていたが、difDataを出力対象にしていなかった。