### PR TITLE
[0006/html-converter] HTMLページのコンバートに対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,11 @@
     <form name="options">
       変換元の色変化仕様：
       <input type="radio" name="colorFlg" value="current" checked="checked"> ParaFla (現行)　
-      <input type="radio" name="colorFlg" value="old"> ParaFla (MFV2さんソースv4以前)
+      <input type="radio" name="colorFlg" value="old"> ParaFla (MFV2さんソースv4以前)<br>
+      文字コード：
+      <input type="radio" name="encodeFlg" value="shift-jis" checked="checked"> Shift-JIS　
+      <input type="radio" name="encodeFlg" value="euc-jp"> EUC-JP　
+      <input type="radio" name="encodeFlg" value="utf-8"> UTF-8
     </form>
     <div id="droparea" class="droparea">
       JavaScriptが無効か、非対応のブラウザです

--- a/js/main.js
+++ b/js/main.js
@@ -258,7 +258,7 @@ g_keyObj.c16i[8] = 15;
 const main = () => {
     const droparea = document.getElementById('droparea');
 
-    droparea.textContent = 'ここにdos.txtをドロップ'
+    droparea.textContent = '譜面ファイル/HTMLファイルをドロップ';
     document.getElementById('version').textContent = g_version;
 
     droparea.addEventListener('dragover', event => {


### PR DESCRIPTION
## 変更内容
1. HTMLページのコンバートに部分対応しました。
譜面データ(dos.txt)と同じように、htmlファイルをドロップするとhtmlファイルに変換されます。
変換したhtmlファイルは「UTF-8」にエンコードされます。

### 変換仕様
- HTMLファイルかどうかはHTMLテキスト内に`<h`が含まれ、かつ後ろに`>`があるもの
を対象とします。(`<html>`もしくは`<head>`タグがあることが前提)
※それ以外は譜面データと扱います。
- HTMLファイル中にmetaタグを検出し、charsetを`utf-8`にします。
- objectタグ、embedタグを検出し、CW Editionのdiv要素、input要素を挿入します。
※譜面データは`dos_js.txt`で作成する前提となっています。
- headタグにscriptタグ(javascriptファイル用)、linkタグ(cssファイル用)を挿入します。
- headタグが無ければ、headタグ、metaタグ、titleタグを追加で補完します。
- DOCTYPE指定されている場合、自動でHTML5用の記述`<!DOCTYPE html>`に置き換えます。
無い場合は追加します。

2. 譜面データ作成時、譜面ヘッダー：musicUrlを自動で付加するようにしました。

## 変更理由
1. HTMLページの移植をより容易にするため。
2. そのまま起動しやすくするため。

## その他コメント
- HTMLコンバートについては、機械的に行っています。
このためページによっては表示崩れが発生することがあります。
- `<pre>`タグがある場合、レイアウトが崩れます。
CW Editionのdiv要素の前後に`<pre>`タグを入れないでください。

```html
<pre> <!--  取る -->
            <input type="hidden" name="externalDos" id="externalDos" value="dos_js.txt">
            <div id="canvas-frame" style="width:600px"></div>
</pre> <!--  取る -->
```

- 広告が含まれている場合、動作が重い可能性があります。
取れるものは事前に取ってください。
- `<html>`タグ、`<head>`タグが無いものは変換できません。
