### PR TITLE
fix: [0010] metaタグの順序により、変換に失敗することがある問題を修正

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -346,7 +346,10 @@ const htmlConvert = (_dos) => {
     const headStartPos = findPos(_dos, `<head`, `>`);
     const headEndPos = findPos(_dos, `</head`, `>`);
     const embedEndPos = findPos(_dos, `</embed`, `>`);
-    const metaPos = findPos(_dos, `<meta `, `>`);
+
+    const metaCTPos = findPos(_dos, `<meta http-equiv=\"content-type\"`, `>`);
+    const metaCScriptPos = findPos(_dos, `<meta http-equiv=\"content-script-type\"`, `>`);
+    const metaCStylePos = findPos(_dos, `<meta http-equiv=\"content-style-type\"`, `>`);
 
     const prePos = findPos(_dos, `<pre>`, `</pre>`);
     const tablePos = findPos(_dos, `<table`, `</table>`);
@@ -396,11 +399,10 @@ const htmlConvert = (_dos) => {
             `;
     const html5Key = `
             <input type="hidden" name="externalDos" id="externalDos" value="${g_nameObj.dos}">
-            <div id="canvas-frame" style="width:600px"></div>
+            <div id="canvas-frame"></div>
                 `;
     const mainjs = `
             <script src="../js/danoni_main.js" charset="UTF-8"></script>
-            <link rel="stylesheet" type="text/css" href="../css/danoni_main.css">
         </head>
                 `;
     const meta = `<meta charset="utf-8">`;
@@ -423,8 +425,10 @@ const htmlConvert = (_dos) => {
     // header内のmetaタグをutf-8に変換し、scriptタグ、linkタグを追加
     if (headPos[C_START] !== C_NOT_FOUND) {
         html5Text = replaceStr(html5Text, _dos, headEndPos, mainjs);
-        if (metaPos[C_START] !== C_NOT_FOUND) {
-            html5Text = replaceStr(html5Text, _dos, metaPos, meta);
+        if (metaCTPos[C_START] !== C_NOT_FOUND) {
+            html5Text = replaceStr(html5Text, _dos, metaCScriptPos, ``);
+            html5Text = replaceStr(html5Text, _dos, metaCStylePos, ``);
+            html5Text = replaceStr(html5Text, _dos, metaCTPos, meta);
         } else {
             html5Text = replaceStr(html5Text, _dos, headStartPos, metaWithHeader);
         }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. metaタグの順序により、変換に失敗することがある問題を修正しました。
2. cssファイルの読込指定、canvas-frameのwidth指定を取り止めました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. これまでは `<meta` のみを検知していたため、それが文字コード指定で無かった時に意図しない挙動になっていました。
今後は下記を検知して置き換えます。

### 検知するパターン
```html
<meta http-equiv="Content-Script-Type" content="text/javascript"> <!-- この列は消す -->
<meta http-equiv="Content-Style-Type" content="text/css"> <!-- この列は消す -->
<meta http-equiv="Content-Type" content="text/html;charset=shift_jis"> <!-- この列はcharset=utf-8に -->
```

### 変換後
```html
<!-- 消去 -->
<!-- 消去 -->
<meta charset="utf-8">
```
2. 現行のCW Edition(v28時点)ではこれらの要素は不要のため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
